### PR TITLE
deps: bump openzeppelin-contracts 4.8.3 -> 5.6.1

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -12,7 +12,7 @@ fuzz.runs = 1024
 
 [dependencies]
 forge-std = "1.16.1"
-"@openzeppelin-contracts" = "4.8.3"
+"@openzeppelin-contracts" = "5.6.1"
 "rain-math-saturating" = "0.1.1"
 "rain-string" = "0.1.0"
 

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,4 +1,4 @@
-@openzeppelin-contracts-4.8.3/=dependencies/@openzeppelin-contracts-4.8.3/
+@openzeppelin-contracts-5.6.1/=dependencies/@openzeppelin-contracts-5.6.1/
 forge-std-1.16.1/=dependencies/forge-std-1.16.1/
 rain-math-saturating-0.1.1/=dependencies/rain-math-saturating-0.1.1/
 rain-string-0.1.0/=dependencies/rain-string-0.1.0/

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -1,9 +1,9 @@
 [[dependencies]]
 name = "@openzeppelin-contracts"
-version = "4.8.3"
-url = "https://soldeer-revisions.s3.amazonaws.com/@openzeppelin-contracts/4_8_3_22-01-2024_13:13:46_contracts.zip"
-checksum = "c6c0f1d430120cf45a3531a2fe740a4dffa1434ebccac753a59c54bc1ce65db9"
-integrity = "3ecc700e5d25af23c53959baf3cfd3cbadbc0013e80dfca40cee9e7ea34e141d"
+version = "5.6.1"
+url = "https://soldeer-revisions.s3.amazonaws.com/@openzeppelin-contracts/5_6_1_15-03-2026_09:19:50_contracts.zip"
+checksum = "a3b6bc661be858c7c27f60a1708cbebe8c71034b4cc1e9fe270d0a05b069352f"
+integrity = "bce03af7ada1eee21a7fff393f238bcd7cd75a022a4db55ffb6b0dbb32433d35"
 
 [[dependencies]]
 name = "forge-std"

--- a/src/lib/LibFixedPointDecimalArithmeticOpenZeppelin.sol
+++ b/src/lib/LibFixedPointDecimalArithmeticOpenZeppelin.sol
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
 pragma solidity ^0.8.25;
 
-import {Math} from "@openzeppelin-contracts-4.8.3/utils/math/Math.sol";
+import {Math} from "@openzeppelin-contracts-5.6.1/utils/math/Math.sol";
 
 import {FIXED_POINT_ONE} from "./FixedPointDecimalConstants.sol";
 

--- a/src/lib/LibFixedPointDecimalStrings.sol
+++ b/src/lib/LibFixedPointDecimalStrings.sol
@@ -7,7 +7,7 @@ pragma solidity ^0.8.25;
 import {FIXED_POINT_ONE} from "./FixedPointDecimalConstants.sol";
 // Exported for convenience.
 //forge-lint: disable-next-line(unused-import)
-import {Strings} from "@openzeppelin-contracts-4.8.3/utils/Strings.sol";
+import {Strings} from "@openzeppelin-contracts-5.6.1/utils/Strings.sol";
 // Exported for convenience.
 //forge-lint: disable-next-line(unused-import)
 import {LibParseChar} from "rain-string-0.1.0/src/lib/parse/LibParseChar.sol";

--- a/src/lib/format/LibFixedPointDecimalFormat.sol
+++ b/src/lib/format/LibFixedPointDecimalFormat.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.25;
 
 import {FIXED_POINT_ONE} from "../FixedPointDecimalConstants.sol";
-import {Strings} from "@openzeppelin-contracts-4.8.3/utils/Strings.sol";
+import {Strings} from "@openzeppelin-contracts-5.6.1/utils/Strings.sol";
 
 library LibFixedPointDecimalFormat {
     /// @notice Convert a fixed point decimal to a string representation.

--- a/test/src/lib/FixedPointDecimalArithmeticOpenZeppelin.t.sol
+++ b/test/src/lib/FixedPointDecimalArithmeticOpenZeppelin.t.sol
@@ -3,7 +3,7 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {Math} from "@openzeppelin-contracts-4.8.3/utils/math/Math.sol";
+import {Math} from "@openzeppelin-contracts-5.6.1/utils/math/Math.sol";
 
 import {LibFixedPointDecimalArithmeticOpenZeppelin} from "src/lib/LibFixedPointDecimalArithmeticOpenZeppelin.sol";
 import {LibWillOverflow} from "src/lib/LibWillOverflow.sol";


### PR DESCRIPTION
Cascade-bump for the rain.math.float soldeer migration. The OZ Math.Rounding enum reorders between 4.x and 5.x, but our code constructs values via integer cast so the shift is a no-op for the unsigned cases this lib uses. `forge t est` passes 78/78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded OpenZeppelin contracts dependency from version 4.8.3 to 5.6.1, including updates to fixed-point decimal arithmetic and string formatting utilities with corresponding test updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rain.math.fixedpoint/pull/18)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->