### PR TITLE
test: mutation-harden LibFixedPointDecimalParse coverage

### DIFF
--- a/audit/mutation-test-scans.json
+++ b/audit/mutation-test-scans.json
@@ -1,0 +1,19 @@
+[
+  {
+    "timestamp": "2026-06-15T00:00:00Z",
+    "commit": "dc85846152e2fd42f8f2c07feb72cc1abc708674",
+    "publishedTag": "v0.2.0",
+    "commitsAheadOfTag": 0,
+    "scope": "LibFixedPointDecimalParse.decimalStringTofixedPoint",
+    "tool": "adversarial-mutation-test",
+    "skillVersion": "0.24.0",
+    "summary": {
+      "behaviours": 15,
+      "survivingMutantsVsExisting": 2,
+      "gapsFilled": 2,
+      "equivalentMutants": 2,
+      "newTests": 2,
+      "filed": []
+    }
+  }
+]

--- a/src/lib/parse/LibFixedPointDecimalParse.sol
+++ b/src/lib/parse/LibFixedPointDecimalParse.sol
@@ -13,7 +13,9 @@ library LibFixedPointDecimalParse {
     /// Converts a decimal string to a fixed point decimal. Returns error
     /// selector if the string is not a valid fixed point decimal string. Fails
     /// on overflow and precision loss, as well as invalid characters in any
-    /// position. DOES NOT support scientific notation.
+    /// position. A decimal point MUST be followed by at least one digit; an
+    /// empty fraction such as "1." is invalid. DOES NOT support scientific
+    /// notation.
     /// Caller MUST check the error selector is 0 before using the value.
     /// @param str The string to convert.
     /// @return errorSelector 0 if successful, otherwise the error selector.
@@ -48,6 +50,12 @@ library LibFixedPointDecimalParse {
                 cursor++;
                 uint256 fracStart = cursor;
                 cursor = LibParseChar.skipMask(cursor, end, CMASK_NUMERIC_0_9);
+
+                // The decimal point MUST be followed by at least one digit.
+                // An empty fraction is malformed.
+                if (cursor == fracStart) {
+                    return (ParseDecimalInvalidString.selector, 0);
+                }
 
                 // Ensure there's no unprocessed garbage.
                 if (cursor < end) {

--- a/test/src/lib/parse/LibFixedPointDecimalParse.decimalStringToFixedPoint.t.sol
+++ b/test/src/lib/parse/LibFixedPointDecimalParse.decimalStringToFixedPoint.t.sol
@@ -112,4 +112,42 @@ contract LibFixedPointDecimalParseTest is Test {
             ParseDecimalOverflow.selector
         );
     }
+
+    /// Failure because the FRACTIONAL part itself overflows a `uint256` while
+    /// being parsed by `unsafeDecimalStringToInt`, before the digit-count
+    /// precision-loss check is reached. A frac of 78 nines cannot fit in a
+    /// `uint256` so the inner integer parse returns `ParseDecimalOverflow`, and
+    /// that selector is propagated unchanged from the fractional-parse error
+    /// branch.
+    function testDecimalStringToFixedPointFailureFractionalPartOverflow() external pure {
+        // 78 nines after the point. 1e78 > type(uint256).max so the inner
+        // unsafeDecimalStringToInt overflows.
+        checkDecimalStringToFixedPointFailure(
+            "0.999999999999999999999999999999999999999999999999999999999999999999999999999999",
+            ParseDecimalOverflow.selector
+        );
+        // 79 digits, leading non-zero, also overflows the inner integer parse.
+        checkDecimalStringToFixedPointFailure(
+            "0.9000000000000000000000000000000000000000000000000000000000000000000000000000009",
+            ParseDecimalOverflow.selector
+        );
+    }
+
+    /// A character immediately after the integer part that is NOT a decimal
+    /// point must be rejected as an invalid string by the decimal-point gate.
+    /// Critically, `"1x"` has no further input after the bad character, so if
+    /// the decimal-point gate is bypassed the parse wrongly SUCCEEDS as `1e18`
+    /// rather than erroring; this is what distinguishes the decimal-point gate
+    /// from the downstream trailing-garbage gate (which the pre-existing corrupt
+    /// integer tests already reach via inputs whose garbage is caught later).
+    function testDecimalStringToFixedPointInvalidAfterInteger() external pure {
+        // Non-point character directly after the integer, with nothing after it,
+        // so the decimal-point gate is the only thing that can reject it.
+        checkDecimalStringToFixedPointFailure("1x", ParseDecimalInvalidString.selector);
+        checkDecimalStringToFixedPointFailure("10x", ParseDecimalInvalidString.selector);
+        // A bare trailing decimal point with no fractional digits is a valid
+        // empty fraction and parses as the integer value (the gate accepts the
+        // point itself).
+        checkDecimalStringToFixedPoint("1.", 1e18);
+    }
 }

--- a/test/src/lib/parse/LibFixedPointDecimalParse.decimalStringToFixedPoint.t.sol
+++ b/test/src/lib/parse/LibFixedPointDecimalParse.decimalStringToFixedPoint.t.sol
@@ -145,9 +145,55 @@ contract LibFixedPointDecimalParseTest is Test {
         // so the decimal-point gate is the only thing that can reject it.
         checkDecimalStringToFixedPointFailure("1x", ParseDecimalInvalidString.selector);
         checkDecimalStringToFixedPointFailure("10x", ParseDecimalInvalidString.selector);
-        // A bare trailing decimal point with no fractional digits is a valid
-        // empty fraction and parses as the integer value (the gate accepts the
-        // point itself).
-        checkDecimalStringToFixedPoint("1.", 1e18);
+        // A bare trailing decimal point with no fractional digits is a
+        // malformed empty fraction and is rejected.
+        checkDecimalStringToFixedPointFailure("1.", ParseDecimalInvalidString.selector);
+    }
+
+    /// An empty fraction is invalid. The decimal point MUST be followed by at
+    /// least one digit, so every integer prefix with a bare trailing point is
+    /// rejected as an invalid string.
+    function testDecimalStringToFixedPointEmptyFraction() external pure {
+        checkDecimalStringToFixedPointFailure("0.", ParseDecimalInvalidString.selector);
+        checkDecimalStringToFixedPointFailure("1.", ParseDecimalInvalidString.selector);
+        checkDecimalStringToFixedPointFailure("123.", ParseDecimalInvalidString.selector);
+        checkDecimalStringToFixedPointFailure("00.", ParseDecimalInvalidString.selector);
+        checkDecimalStringToFixedPointFailure(
+            "115792089237316195423570985008687907853269984665640564039457.", ParseDecimalInvalidString.selector
+        );
+        // Scientific notation is unsupported, so nothing following the bare
+        // point can make the empty fraction parseable.
+        checkDecimalStringToFixedPointFailure("1.e5", ParseDecimalInvalidString.selector);
+        // A lone point also has an empty integer part, which is rejected
+        // before the fraction is considered.
+        checkDecimalStringToFixedPointFailure(".", ParseEmptyDecimalString.selector);
+        // A point-led fraction has an empty integer part, which is rejected
+        // before the fraction is considered.
+        checkDecimalStringToFixedPointFailure(".5", ParseEmptyDecimalString.selector);
+    }
+
+    /// Any integer with a bare trailing decimal point appended is an invalid
+    /// string. The integer is bounded so it cannot overflow the fixed point
+    /// representation, leaving the empty fraction as the only rejection.
+    function testDecimalStringToFixedPointEmptyFractionFuzz(uint256 value) external pure {
+        value = bound(value, 0, type(uint256).max / 1e18);
+        checkDecimalStringToFixedPointFailure(
+            string.concat(vm.toString(value), "."), ParseDecimalInvalidString.selector
+        );
+    }
+
+    /// The valid forms adjacent to the rejected empty fractions parse to the
+    /// values given by decimal semantics: the same digits with an explicit
+    /// fractional digit, and the bare integer without the point.
+    function testDecimalStringToFixedPointEmptyFractionAdjacentValid() external pure {
+        checkDecimalStringToFixedPoint("0", 0);
+        checkDecimalStringToFixedPoint("0.0", 0);
+        checkDecimalStringToFixedPoint("1", 1e18);
+        checkDecimalStringToFixedPoint("1.0", 1e18);
+        checkDecimalStringToFixedPoint("123", 123e18);
+        checkDecimalStringToFixedPoint("123.0", 123e18);
+        checkDecimalStringToFixedPoint(
+            "115792089237316195423570985008687907853269984665640564039457.584007913129639935", type(uint256).max
+        );
     }
 }


### PR DESCRIPTION
## What

Scoped adversarial-mutation-test coverage pass over the core string→fixed-point
parser `LibFixedPointDecimalParse.decimalStringTofixedPoint`. This was the only
module with a real coverage gap (97.5% lines / 88.9% branches; every other module
is at 100%).

**Update (2026-07-04 rework note):** per the human design ruling recorded in #24
— an EMPTY FRACTION IS INVALID — this PR no longer pins `"1."` as a valid empty
fraction. The parser fix for #24 (branch `fix-24-trailing-decimal-revert`,
PR #25) is merged into this branch so the parser fix and the hardened suite land
together: the decimal-point gate in `src/lib/parse/LibFixedPointDecimalParse.sol`
now requires at least one digit after the point, returning
`ParseDecimalInvalidString.selector` for a bare trailing point, and the `"1."`
acceptance pin is replaced with a revert pin on that exact selector. The two
fractional-overflow tests and the `"1x"`/`"10x"` decimal-point-gate tests are
kept as-is.

The discipline: for each behaviour, break the exact line and run the whole suite.
Mutants the existing tests already kill are credited (no new test). Only mutants
that **survive the existing suite** (real gaps) get a new discriminating test that
passes clean and fails under the mutation.

## Group hardened

`decimalStringTofixedPoint` — 15 behaviours probed. The existing example + round-trip
tests already kill most mutants. Two genuine survivors were found and killed.

## Mutation matrix (behaviour → mutation → killer)

| Behaviour | Mutation | vs existing suite | Disposition |
|---|---|---|---|
| Integer overflow guard | `!=` → `==` | killed | existing overflow test ✓ |
| Decimal-point gate (L44) | `== 0` → `false` | **SURVIVED** | **GAP → new `testDecimalStringToFixedPointInvalidAfterInteger`** |
| Garbage-after-frac gate | `cursor<end` → `false` | killed | existing ✓ |
| Strip lower-bound (L60) | `>=` → `>` fracStart | survived (both) | **equivalent mutant** — a `'0'` at fracStart contributes 0 whether stripped or parsed |
| Strip mask flag | `== 1` → `== 0` | killed | existing ✓ |
| Strip recombine | `+1` → `+0` | killed | existing ✓ |
| Strip init | `cursor-1` → `cursor-0` | killed | existing ✓ |
| Strip decrement | `--` → `++` | killed | existing ✓ |
| `cursor > fracStart` gate | → `true` | killed | existing ✓ |
| Frac-error propagate (L71) | `(errorSelector,0)` → `(0,0)` | **SURVIVED** | **GAP → new `testDecimalStringToFixedPointFailureFractionalPartOverflow`** |
| Precision-loss boundary | `>18` → `>19` | killed | existing precision-loss test ✓ |
| Precision-loss boundary | `>18` → `>=18` | killed | existing ✓ |
| `ooms = 18 - digits` | → `17 - digits` | killed | existing ✓ |
| Frac-add overflow guard (L84) | `<` → `<=` | survived (both) | **equivalent mutant** — `scaledFrac` is always strictly > 0 (frac > 0 after strip, `frac*10**ooms < 2^256`), so `value == preValue` is impossible |
| Frac-add overflow guard | `if (value<preValue)` → `if (false)` | killed | existing overflow test ✓ |

### The two gaps filled

- **Fractional-part overflow (line 71 — previously the one uncovered line).** A
  fraction with more than 77 digits overflows `uint256` inside the inner
  `unsafeDecimalStringToInt`, *before* the `digits > 18` precision-loss check is
  reached, and the resulting `ParseDecimalOverflow` selector is returned from the
  fractional error branch. No existing test passed an overflowing fraction. New
  test pins a 78-nine fraction → `ParseDecimalOverflow`.
- **Decimal-point gate (line 44).** A non-point character directly after the
  integer **with nothing after it** (`"1x"`) must be rejected as an invalid string.
  Bypassing the gate makes the parse wrongly *succeed* as `1e18`. The pre-existing
  corrupt-integer tests only reached this code via inputs (`"1a1.1"`) whose garbage
  is caught by a *later* gate, so they did not discriminate the decimal-point gate
  itself. New test pins `"1x"`/`"10x"` → `ParseDecimalInvalidString`, plus `"1."`
  → `ParseDecimalInvalidString` (a bare trailing point is a malformed empty
  fraction per the ruling in #24; this pin was originally acceptance → `1e18` and
  was replaced per the rework note).

## Parser fix carried from #24 (PR #25 merged in)

Rejected now (`ParseDecimalInvalidString`, selector `0x3e8e62d6`):
- `"1."`, `"0."`, `"123."`, `"00."`, `"115792089237316195423570985008687907853269984665640564039457."` — the whole category: any integer digits followed by a bare trailing point
- `"1.e5"` — scientific notation is unsupported here, so nothing after the bare point can rescue the empty fraction
- Fuzz: every non-overflowing integer with `"."` appended

Unchanged:
- `"1"`, `"1.0"`, `"0"`, `"0.0"`, `"123"`, `"123.0"`, and the `uint256`-max string still parse to the same values as before (pinned)
- `"."` and `".5"` still reject with `ParseEmptyDecimalString` (empty integer part, rejected before the fraction is considered; their status is pinned, not changed)
- Sweep for reliance on the permissive acceptance: the only occurrence in the repo was the `"1."` pin in this suite, replaced here. `LibFixedPointDecimalFormat.fixedPointToDecimalString` only emits a `.` when the fraction is nonzero with at least one nonzero digit after it, so the `testStringRoundTripFuzz` round-trip is unaffected.

This repo has no generated pointer/deploy-constant files and nothing deployed
(pure `internal` library), so no pin regeneration and no redeploy is required.

## Remaining-gaps checklist

- [x] All 15 enumerated behaviours of `decimalStringTofixedPoint` probed.
- [x] Both genuine surviving mutants (decimal-point gate, frac-error propagation) killed.
- [x] Two residual survivors confirmed **equivalent mutants** (strip lower-bound `>=`/`>`, frac-add guard `<`/`<=`) — no behaviour can distinguish them, no test added.
- [x] `src/` change is exactly the single empty-fraction guard from the #24 fix; full suite green (83 tests, was 78); `forge fmt --check` and `forge lint` clean.
- [ ] Other modules (`LibFixedPointDecimalScale`, `LibWillOverflow`, `LibFixedPointDecimalArithmeticOpenZeppelin`, `LibFixedPointDecimalFormat`) are at 100% line/branch and heavily fuzzed against a slow reference implementation; not re-probed in this scoped pass (candidates for a follow-up scoped pass if desired).

## Triage note (not a bug, not in this PR's scope to change)

A fraction of >77 digits reports `ParseDecimalOverflow` rather than
`ParseDecimalPrecisionLoss`, because the inner-parse overflow check runs before the
`digits > 18` check. Both outcomes reject the (invalid) string; only the selector
differs from a "precision-loss-first" reading. The new test pins the current
(Overflow) behaviour.

Closes #24

## QA
- Discriminating tests: `testDecimalStringToFixedPointEmptyFraction`, `testDecimalStringToFixedPointEmptyFractionFuzz(uint256)`, `testDecimalStringToFixedPointInvalidAfterInteger` (carries the replaced `"1."` revert pin) — each fails on base (verified by deleting the empty-fraction guard from `decimalStringTofixedPoint`, i.e. restoring the pre-#24-fix parser, and running the parse suite: exactly these 3 failed with `0x00000000… != 0x3e8e62d6…` — success where `ParseDecimalInvalidString` is required — while both fractional-overflow tests and the pre-existing tests stayed green; guard restored, working tree byte-identical to the pushed commit, full suite re-run green 83/83)
- Mutations applied: `src/lib/parse/LibFixedPointDecimalParse.sol` empty-fraction guard `if (cursor == fracStart) { return (ParseDecimalInvalidString.selector, 0); }` → deleted (re-allow the empty fraction) → killed by all three discriminating tests above; the test-suite side is the 15-behaviour matrix in this body
- Oracle: expected values for valid forms are Solidity decimal literals (`1e18`, `123e18`, `type(uint256).max`) derived from decimal semantics, never recomputed through the parser; the expected selector is the pre-existing `ParseDecimalInvalidString` error named by the ruling in #24
- Category check: #24 asks that the decimal-point gate require at least one digit after the point, that the revert be pinned on the exact selector, and a sweep for tests/fixtures relying on the acceptance; covered the category (`"0."`, `"1."`, `"123."`, `"00."`, 60-digit integer + `"."`, `"1.e5"`, and a fuzz over all non-overflowing integers + `"."`), pinned selector `0x3e8e62d6`, sweep found only this suite's former `"1."` pin (replaced). #24's category note about sibling parsers in OTHER repos (rain.math.float, rainlang literal parsing) is outside this repo and stays with #24's note; this PR closes the `LibFixedPointDecimalParse` fix it names.

Test summary: merged head 83 passed / 0 failed; `forge fmt --check` and `forge lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
