### PR TITLE
fix: reject bare trailing decimal point (empty fraction) in decimal string parse

### DIFF
--- a/audit/mutation-test-scans.json
+++ b/audit/mutation-test-scans.json
@@ -1,0 +1,19 @@
+[
+  {
+    "timestamp": "2026-06-15T00:00:00Z",
+    "commit": "dc85846152e2fd42f8f2c07feb72cc1abc708674",
+    "publishedTag": "v0.2.0",
+    "commitsAheadOfTag": 0,
+    "scope": "LibFixedPointDecimalParse.decimalStringTofixedPoint",
+    "tool": "adversarial-mutation-test",
+    "skillVersion": "0.24.0",
+    "summary": {
+      "behaviours": 15,
+      "survivingMutantsVsExisting": 2,
+      "gapsFilled": 2,
+      "equivalentMutants": 2,
+      "newTests": 2,
+      "filed": []
+    }
+  }
+]

--- a/src/lib/parse/LibFixedPointDecimalParse.sol
+++ b/src/lib/parse/LibFixedPointDecimalParse.sol
@@ -13,7 +13,9 @@ library LibFixedPointDecimalParse {
     /// Converts a decimal string to a fixed point decimal. Returns error
     /// selector if the string is not a valid fixed point decimal string. Fails
     /// on overflow and precision loss, as well as invalid characters in any
-    /// position. DOES NOT support scientific notation.
+    /// position. A decimal point MUST be followed by at least one digit; an
+    /// empty fraction such as "1." is invalid. DOES NOT support scientific
+    /// notation.
     /// Caller MUST check the error selector is 0 before using the value.
     /// @param str The string to convert.
     /// @return errorSelector 0 if successful, otherwise the error selector.
@@ -48,6 +50,12 @@ library LibFixedPointDecimalParse {
                 cursor++;
                 uint256 fracStart = cursor;
                 cursor = LibParseChar.skipMask(cursor, end, CMASK_NUMERIC_0_9);
+
+                // The decimal point MUST be followed by at least one digit.
+                // An empty fraction is malformed.
+                if (cursor == fracStart) {
+                    return (ParseDecimalInvalidString.selector, 0);
+                }
 
                 // Ensure there's no unprocessed garbage.
                 if (cursor < end) {

--- a/test/src/lib/parse/LibFixedPointDecimalParse.decimalStringToFixedPoint.t.sol
+++ b/test/src/lib/parse/LibFixedPointDecimalParse.decimalStringToFixedPoint.t.sol
@@ -112,4 +112,42 @@ contract LibFixedPointDecimalParseTest is Test {
             ParseDecimalOverflow.selector
         );
     }
+
+    /// Failure because the FRACTIONAL part itself overflows a `uint256` while
+    /// being parsed by `unsafeDecimalStringToInt`, before the digit-count
+    /// precision-loss check is reached. A frac of 78 nines cannot fit in a
+    /// `uint256` so the inner integer parse returns `ParseDecimalOverflow`, and
+    /// that selector is propagated unchanged from the fractional-parse error
+    /// branch.
+    function testDecimalStringToFixedPointFailureFractionalPartOverflow() external pure {
+        // 78 nines after the point. 1e78 > type(uint256).max so the inner
+        // unsafeDecimalStringToInt overflows.
+        checkDecimalStringToFixedPointFailure(
+            "0.999999999999999999999999999999999999999999999999999999999999999999999999999999",
+            ParseDecimalOverflow.selector
+        );
+        // 79 digits, leading non-zero, also overflows the inner integer parse.
+        checkDecimalStringToFixedPointFailure(
+            "0.9000000000000000000000000000000000000000000000000000000000000000000000000000009",
+            ParseDecimalOverflow.selector
+        );
+    }
+
+    /// A character immediately after the integer part that is NOT a decimal
+    /// point must be rejected as an invalid string by the decimal-point gate.
+    /// Critically, `"1x"` has no further input after the bad character, so if
+    /// the decimal-point gate is bypassed the parse wrongly SUCCEEDS as `1e18`
+    /// rather than erroring; this is what distinguishes the decimal-point gate
+    /// from the downstream trailing-garbage gate (which the pre-existing corrupt
+    /// integer tests already reach via inputs whose garbage is caught later).
+    function testDecimalStringToFixedPointInvalidAfterInteger() external pure {
+        // Non-point character directly after the integer, with nothing after it,
+        // so the decimal-point gate is the only thing that can reject it.
+        checkDecimalStringToFixedPointFailure("1x", ParseDecimalInvalidString.selector);
+        checkDecimalStringToFixedPointFailure("10x", ParseDecimalInvalidString.selector);
+        // A bare trailing decimal point with no fractional digits is a valid
+        // empty fraction and parses as the integer value (the gate accepts the
+        // point itself).
+        checkDecimalStringToFixedPoint("1.", 1e18);
+    }
 }

--- a/test/src/lib/parse/LibFixedPointDecimalParse.decimalStringToFixedPoint.t.sol
+++ b/test/src/lib/parse/LibFixedPointDecimalParse.decimalStringToFixedPoint.t.sol
@@ -145,9 +145,55 @@ contract LibFixedPointDecimalParseTest is Test {
         // so the decimal-point gate is the only thing that can reject it.
         checkDecimalStringToFixedPointFailure("1x", ParseDecimalInvalidString.selector);
         checkDecimalStringToFixedPointFailure("10x", ParseDecimalInvalidString.selector);
-        // A bare trailing decimal point with no fractional digits is a valid
-        // empty fraction and parses as the integer value (the gate accepts the
-        // point itself).
-        checkDecimalStringToFixedPoint("1.", 1e18);
+        // A bare trailing decimal point with no fractional digits is a
+        // malformed empty fraction and is rejected.
+        checkDecimalStringToFixedPointFailure("1.", ParseDecimalInvalidString.selector);
+    }
+
+    /// An empty fraction is invalid. The decimal point MUST be followed by at
+    /// least one digit, so every integer prefix with a bare trailing point is
+    /// rejected as an invalid string.
+    function testDecimalStringToFixedPointEmptyFraction() external pure {
+        checkDecimalStringToFixedPointFailure("0.", ParseDecimalInvalidString.selector);
+        checkDecimalStringToFixedPointFailure("1.", ParseDecimalInvalidString.selector);
+        checkDecimalStringToFixedPointFailure("123.", ParseDecimalInvalidString.selector);
+        checkDecimalStringToFixedPointFailure("00.", ParseDecimalInvalidString.selector);
+        checkDecimalStringToFixedPointFailure(
+            "115792089237316195423570985008687907853269984665640564039457.", ParseDecimalInvalidString.selector
+        );
+        // Scientific notation is unsupported, so nothing following the bare
+        // point can make the empty fraction parseable.
+        checkDecimalStringToFixedPointFailure("1.e5", ParseDecimalInvalidString.selector);
+        // A lone point also has an empty integer part, which is rejected
+        // before the fraction is considered.
+        checkDecimalStringToFixedPointFailure(".", ParseEmptyDecimalString.selector);
+        // A point-led fraction has an empty integer part, which is rejected
+        // before the fraction is considered.
+        checkDecimalStringToFixedPointFailure(".5", ParseEmptyDecimalString.selector);
+    }
+
+    /// Any integer with a bare trailing decimal point appended is an invalid
+    /// string. The integer is bounded so it cannot overflow the fixed point
+    /// representation, leaving the empty fraction as the only rejection.
+    function testDecimalStringToFixedPointEmptyFractionFuzz(uint256 value) external pure {
+        value = bound(value, 0, type(uint256).max / 1e18);
+        checkDecimalStringToFixedPointFailure(
+            string.concat(vm.toString(value), "."), ParseDecimalInvalidString.selector
+        );
+    }
+
+    /// The valid forms adjacent to the rejected empty fractions parse to the
+    /// values given by decimal semantics: the same digits with an explicit
+    /// fractional digit, and the bare integer without the point.
+    function testDecimalStringToFixedPointEmptyFractionAdjacentValid() external pure {
+        checkDecimalStringToFixedPoint("0", 0);
+        checkDecimalStringToFixedPoint("0.0", 0);
+        checkDecimalStringToFixedPoint("1", 1e18);
+        checkDecimalStringToFixedPoint("1.0", 1e18);
+        checkDecimalStringToFixedPoint("123", 123e18);
+        checkDecimalStringToFixedPoint("123.0", 123e18);
+        checkDecimalStringToFixedPoint(
+            "115792089237316195423570985008687907853269984665640564039457.584007913129639935", type(uint256).max
+        );
     }
 }


### PR DESCRIPTION
## What

`LibFixedPointDecimalParse.decimalStringTofixedPoint` accepted a bare trailing decimal point (`"1."`) as a valid empty fraction, parsing it as the plain integer value. Per the org design ruling recorded in #24 (2026-07-04, review of PR #22): an empty fraction is INVALID — a trailing point with no fractional digits is a malformed literal, not UX generosity.

The decimal-point gate now requires at least one digit after the point: after consuming the point and skipping fraction digits, finding the cursor still at the fraction start returns `ParseDecimalInvalidString.selector` (the repo's existing malformed-input error, exactly as the ruling names it).

Per the rework note on #22 ("land the parser fix + this suite together"), this branch is based on #22's head and carries its mutation-hardening suite unchanged except for the single `"1."` acceptance pin, which is replaced with a revert pin on the exact selector. The fractional-overflow tests and the `"1x"`/`"10x"` decimal-point-gate tests are kept as-is. When this merges, #22's commits land with it.

Closes #24

## Behavior

Rejected now (`ParseDecimalInvalidString`, selector `0x3e8e62d6`):
- `"1."`, `"0."`, `"123."`, `"00."`, `"115792089237316195423570985008687907853269984665640564039457."` — the whole category: any integer digits followed by a bare trailing point
- `"1.e5"` — scientific notation is unsupported here, so nothing after the bare point can rescue the empty fraction
- Fuzz: every non-overflowing integer with `"."` appended

Unchanged:
- `"1"`, `"1.0"`, `"0"`, `"0.0"`, `"123"`, `"123.0"`, and the `uint256`-max string still parse to the same values as before (pinned)
- `"."` and `".5"` still reject with `ParseEmptyDecimalString` (empty integer part, rejected before the fraction is considered; their status is pinned, not changed)
- Sweep for reliance on the permissive acceptance: the only occurrence in the repo was the `"1."` pin from #22, replaced here. `LibFixedPointDecimalFormat.fixedPointToDecimalString` only emits a `.` when the fraction is nonzero with at least one nonzero digit after it, so the `testStringRoundTripFuzz` round-trip is unaffected.

## Deploy pins

This repo has no generated pointer/deploy-constant files and nothing deployed (pure `internal` library), so no pin regeneration and no redeploy is required.

## QA
- Discriminating tests: `testDecimalStringToFixedPointEmptyFraction`, `testDecimalStringToFixedPointEmptyFractionFuzz(uint256)`, `testDecimalStringToFixedPointInvalidAfterInteger` (holds the replaced `"1."` revert pin) — each fails on base (verified by stashing the `src/` change and running the suite against the unchanged parser: exactly these 3 failed with `0x00000000… != 0x3e8e62d6…`, base returning success where `ParseDecimalInvalidString` is required; base suite itself green, 80/80)
- Mutations applied: `src/lib/parse/LibFixedPointDecimalParse.sol` empty-fraction guard `if (cursor == fracStart)` → `if (false)` (re-allow the empty fraction) → killed by all three discriminating tests above; guard restored and full suite re-run green
- Oracle: expected values for valid forms are Solidity decimal literals (`1e18`, `123e18`, `type(uint256).max`) derived from decimal semantics, never recomputed through the parser; the expected selector is the pre-existing `ParseDecimalInvalidString` error named by the ruling in #24
- Category check: issue asks that the decimal-point gate require at least one digit after the point, with the revert pinned on the exact selector, plus a sweep for tests/fixtures relying on the acceptance; covered the category (`"0."`, `"1."`, `"123."`, `"00."`, 60-digit integer + `"."`, `"1.e5"`, and a fuzz over all non-overflowing integers + `"."`), pinned the exact selector, and the sweep found only the #22 pin (replaced). The issue's category note about sibling parsers in OTHER repos (rain.math.float, rainlang literal parsing) is outside this repo; #24 itself scopes this PR to `LibFixedPointDecimalParse`.

Test summary: base 80 passed / 0 failed; with fix 83 passed / 0 failed (3 new test functions); `forge fmt` produced no further changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
