### PR TITLE
chore(soldeer): bump [package].version to 0.2.2 for next-version release lifecycle

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rain-math-fixedpoint"
-version = "0.2.1"
+version = "0.2.2"
 
 [profile.default]
 libs = ["dependencies"]


### PR DESCRIPTION
Closes #26

## What

Bump `foundry.toml` `[package].version` from `0.2.1` to `0.2.2` — the next, in-development (unpublished) Soldeer revision.

The shared `rainix-autopublish` reusable (pinned `@main`) moved from auto-bump to the **next-version release lifecycle** (rainlanguage/rainix#264). Under it, `[package].version` must be **strictly ahead** of the latest published revision; when they are equal the publish gate fails loud on the next Solidity-content merge:

> `foundry.toml [package].version (0.2.1) is not ahead of the published revision (0.2.1) …`

This one-time bump moves the repo onto the new lifecycle; thereafter each publish self-bumps.

## Why 0.2.2

- `foundry.toml [package].version` = `0.2.1`
- Latest published `rain-math-fixedpoint` Soldeer revision = `0.2.1` (equal → gate fails)
- Next unpublished patch = `0.2.2` (strictly ahead ✓)

Pure-library repo — no version-keyed generated artifacts (`src/generated` absent), so no `soldeer-generate-cmd:` wiring is required (per the issue's guidance).

## QA evidence

Per QA-GUIDE.md §8. This is a **config-only** change to `foundry.toml [package].version`; there is no Solidity/behavioral surface introduced or altered — no function, branch, or assertion exists to mutation-test, and the compiled bytecode and existing test suite are independent of the `[package].version` string.

- **Correctness oracle (independent):** the autopublish invariant — in-dev version strictly greater than the latest published revision. Verified independently against the live Soldeer registry: latest published `rain-math-fixedpoint` = `0.2.1`; the pre-change value `0.2.1` is *equal* (would fail the gate), and `0.2.2 > 0.2.1` satisfies strict-ahead.
- **No weakening:** no test or assertion is added, removed, or loosened; the version string does not gate any test.
- **Build:** `forge build` succeeds with the new config (toml parses; deps resolve).
- **Scope:** single line, single file.

Ref: rainlanguage/rainix#264

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version from 0.2.1 to 0.2.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->